### PR TITLE
Fix particle rendering bug and exceptions partially clearing particles

### DIFF
--- a/src/main/java/dev/phonis/cannontracer/trace/ParticleSystem.java
+++ b/src/main/java/dev/phonis/cannontracer/trace/ParticleSystem.java
@@ -134,8 +134,10 @@ public class ParticleSystem {
             // First get the closest points, then iterate over until particle list is full
             List<Point> points = pointTree.nearest(locationToArray(loc), maxParticles);
             List<TraceParticle> particles = new ArrayList<>(maxParticles + 2);
-            for (Point point : points) {
-                if (particles.size() >= maxParticles) break;
+            // For some reason, points in this list go from farthest to closest, so have to iterate backwards
+            for (int i = points.size() - 1; i >= 0; i--) {
+                if (particles.size() >= maxParticles) break; // Stop if the particle list is already full
+                Point point = points.get(i);
                 if (point.PlayerParticle != null) particles.add(point.PlayerParticle);
                 if (point.SandParticle != null) particles.add(point.SandParticle);
                 if (point.TNTParticle != null) particles.add(point.TNTParticle);

--- a/src/main/java/dev/phonis/cannontracer/trace/ParticleSystem.java
+++ b/src/main/java/dev/phonis/cannontracer/trace/ParticleSystem.java
@@ -159,6 +159,7 @@ public class ParticleSystem {
                 // For every particle, remove from associated point, and remove point if empty
                 for (TraceParticle particle : particles) {
                     Point point = pointTree.search(locationToArray(particle.getLocation()));
+                    if (point == null) continue; // Support partially clearing particles without cleaning up despawnQueue
                     point.delParticle(particle.getType());
                     if (point.isEmpty()) removeEmptyPoint(point.Loc);
                 }
@@ -177,9 +178,20 @@ public class ParticleSystem {
     }
 
     public void removeIf(Predicate<TraceParticle> filter) {
-        for (Point point : activePoints.values()) {
+        // We won't remove particles from despawnQueue bc too computationally intensive to support.
+        // despawnQueue can handle particles detached from their points.
+
+        List<Location> pointsToRemove = new ArrayList<>();
+
+        Iterator<Point> pointIterator = activePoints.values().iterator();
+        while (pointIterator.hasNext()) {
+            Point point = pointIterator.next();
             point.delParticleIf(filter);
-            if (point.isEmpty()) removeEmptyPoint(point.Loc);
+            if (point.isEmpty()) pointsToRemove.add(point.Loc);
+        }
+
+        for (Location loc : pointsToRemove) {
+            removeEmptyPoint(loc);
         }
     }
 

--- a/src/main/java/dev/phonis/cannontracer/trace/ParticleSystem.java
+++ b/src/main/java/dev/phonis/cannontracer/trace/ParticleSystem.java
@@ -67,9 +67,9 @@ public class ParticleSystem {
         }
 
         public void delParticleIf(Predicate<TraceParticle> filter) {
-            if (filter.test(PlayerParticle)) PlayerParticle = null;
-            if (filter.test(SandParticle)) SandParticle = null;
-            if (filter.test(TNTParticle)) TNTParticle = null;
+            if (PlayerParticle != null && filter.test(PlayerParticle)) PlayerParticle = null;
+            if (SandParticle != null && filter.test(SandParticle)) SandParticle = null;
+            if (TNTParticle != null && filter.test(TNTParticle)) TNTParticle = null;
         }
 
         public TraceParticle getParticle(ParticleType type) {


### PR DESCRIPTION
- ParticleSystem::getClosestParticles assumed pointTree.nearest() returned list of points ordered from closest to farthest, when it actually returned them from farthest to closest. This caused particles from the nearest N points to be included outward-in, which was noticeable when shooting sand and TNT as the array of particles to return would fill up after only processing half the points.
- ParticleSystem::Point::delParticleIf needed null-check before checking particle types it might not hold against a filter, causing partial clears to fail.
- ParticleSystem::removeIf needed to remove particles from despawn queue.